### PR TITLE
Bump minimum hull.js version to address security issue

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.12",
       "license": "MIT",
       "dependencies": {
-        "hull.js": "^1.0.1",
+        "hull.js": "andriiheonia/hull#semver:^1.0.10",
         "mathjs": "11.11.1",
         "typescript": "^5.2.2"
       },
@@ -918,9 +918,9 @@
       }
     },
     "node_modules/hull.js": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/hull.js/-/hull.js-1.0.1.tgz",
-      "integrity": "sha512-6Nvcv/A5Ewkpga3whhSF0IRw6N82D1xpBRHLOdnsmIKVvCRSLE7dovKj4HX1h5nwI7V0OZ2MM3ft2EAsJsll4w=="
+      "version": "1.0.10",
+      "resolved": "git+ssh://git@github.com/andriiheonia/hull.git#343f6041d53dcd9611f0ab77c8a2b6e14b57e38a",
+      "license": "BSD"
     },
     "node_modules/import-lazy": {
       "version": "4.0.0",
@@ -2041,9 +2041,8 @@
       "dev": true
     },
     "hull.js": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/hull.js/-/hull.js-1.0.1.tgz",
-      "integrity": "sha512-6Nvcv/A5Ewkpga3whhSF0IRw6N82D1xpBRHLOdnsmIKVvCRSLE7dovKj4HX1h5nwI7V0OZ2MM3ft2EAsJsll4w=="
+      "version": "git+ssh://git@github.com/andriiheonia/hull.git#343f6041d53dcd9611f0ab77c8a2b6e14b57e38a",
+      "from": "hull.js@andriiheonia/hull#semver:^1.0.10"
     },
     "import-lazy": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "homepage": "https://github.com/mahetoodang/minimum-bounding-rectangle#readme",
   "dependencies": {
-    "hull.js": "^1.0.1",
+    "hull.js": "andriiheonia/hull#semver:^1.0.10",
     "mathjs": "11.11.1",
     "typescript": "^5.2.2"
   },


### PR DESCRIPTION
I pinned my code to use `hull.js>=1.0.10`, but it is better if this package fix the issue too.

https://github.com/AndriiHeonia/hull/security/advisories/GHSA-q849-wxrc-vqrp
